### PR TITLE
infra: Terraform リモートバックエンド(S3)接続

### DIFF
--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "~> 5.55"
   hashes = [
     "h1:H3mU/7URhP0uCRGK8jeQRKxx2XFzEqLiOq/L2Bbiaxs=",
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
     "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
     "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
     "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",

--- a/infra/backend.tf
+++ b/infra/backend.tf
@@ -1,0 +1,12 @@
+# Terraform リモートステート（S3）
+# ロックは S3 ネイティブ機能（use_lockfile）を使用 — DynamoDB は不要（Terraform 1.10+）。
+# 注: backend ブロックの値は変数を使えないためリテラル。いずれも機密ではない（バケットは公開ブロック済み）。
+terraform {
+  backend "s3" {
+    bucket       = "ee-sqlite-demo-tfstate"
+    key          = "ee-sqlite-demo/terraform.tfstate"
+    region       = "ap-northeast-1"
+    encrypt      = true
+    use_lockfile = true
+  }
+}


### PR DESCRIPTION
## 概要
Terraform のステートを **S3 リモートバックエンド** に移行（issue #18）。別端末からも安全に管理できるようにする。

## 変更
- `infra/backend.tf` 追加: S3 backend + ネイティブロック（`use_lockfile=true`）。**DynamoDB不要**（Terraform 1.10+）。
- ステートバケット `ee-sqlite-demo-tfstate`: versioning / AES256暗号化 / 公開アクセス完全ブロック。
- `.terraform.lock.hcl`: provider lock（aws v5.100.0）。

## 確認済み
- 既存14リソースを新ステートへ `terraform import` 済み。
- `terraform plan` = **0 add / 2 change / 0 destroy**（無害な in-place のみ：API GW詳細メトリクス, S3 force_destroy）。
- 重複していた孤立 CloudFront は削除済み、他プロジェクトへの影響なし。
- 機密スキャン（pre-push-check）クリーン。tfstate/tfvars は未追跡。

Refs #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)