### PR TITLE
security: バックエンドのセキュリティ強化（UI不変）

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -1,5 +1,6 @@
 from rest_framework import viewsets, status
 from rest_framework.decorators import action
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from django.contrib.auth.models import User
 from django.shortcuts import render
@@ -75,14 +76,29 @@ class UserProgressViewSet(viewsets.ModelViewSet):
         serializer = self.get_serializer(progress, many=True)
         return Response(serializer.data)
 
-    @action(detail=False, methods=["post"])
+    # 既存UXを維持するため complete_lesson は未認証でも呼べる（未認証時は保存せず ok を返す）。
+    @action(detail=False, methods=["post"], permission_classes=[AllowAny])
     def complete_lesson(self, request):
-        lesson_id = request.data.get("lesson_id")
-        score = request.data.get("score", 0)
-        time_spent = request.data.get("time_spent", 0)
+        # 入力の検証・型変換（不正値は 500 ではなく 400 を返す）
+        try:
+            lesson_id = int(request.data.get("lesson_id"))
+        except (TypeError, ValueError):
+            return Response(
+                {"error": "lesson_id は整数で指定してください"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        try:
+            score = int(request.data.get("score", 0))
+            time_spent = int(request.data.get("time_spent", 0))
+        except (TypeError, ValueError):
+            return Response(
+                {"error": "score / time_spent は整数で指定してください"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
-        # スコアを100%を超えないように制限
+        # スコアを 0〜100 に、学習時間を 0 以上に制限
         score = min(max(0, score), 100)
+        time_spent = max(0, time_spent)
 
         try:
             lesson = Lesson.objects.get(id=lesson_id)

--- a/engineer_english/settings.py
+++ b/engineer_english/settings.py
@@ -90,13 +90,39 @@ _csrf_trusted = os.getenv("DJANGO_CSRF_TRUSTED_ORIGINS", "").strip()
 if _csrf_trusted:
     CSRF_TRUSTED_ORIGINS = [o for o in _csrf_trusted.split(",") if o]
 
+# 本番（DEBUG=False）でのみ有効化するセキュリティ設定。
+# ローカル開発（DEBUG=True）には影響しない。
+if not DEBUG:
+    # SECRET_KEY が未設定（insecureデフォルトのまま）での本番起動を防ぐ。
+    # ※デプロイ前に必ず環境変数 DJANGO_SECRET_KEY を設定すること。
+    if SECRET_KEY == "django-insecure-change-me":
+        from django.core.exceptions import ImproperlyConfigured
+
+        raise ImproperlyConfigured(
+            "本番(DEBUG=False)では環境変数 DJANGO_SECRET_KEY の設定が必須です。"
+        )
+
+    # HTTPS終端（API Gateway / CloudFront）の背後にいるため、転送ヘッダで判定。
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+    # SSLリダイレクトはリダイレクトループ回避のため既定オフ（必要なら env で有効化）。
+    SECURE_SSL_REDIRECT = os.getenv("DJANGO_SECURE_SSL_REDIRECT", "False") == "True"
+    SECURE_HSTS_SECONDS = int(os.getenv("DJANGO_SECURE_HSTS_SECONDS", "31536000"))
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+    SECURE_HSTS_PRELOAD = True
+    SECURE_CONTENT_TYPE_NOSNIFF = True
+    SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
+    X_FRAME_OPTIONS = "DENY"
+
 # Django REST Framework設定
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework.authentication.SessionAuthentication",
         "rest_framework.authentication.BasicAuthentication",
     ],
+    # 既定は「読み取りは誰でも / 書き込みは認証ユーザーのみ」。
+    # 未認証での書込・削除を防ぐ。GET主体のUIには影響しない。
     "DEFAULT_PERMISSION_CLASSES": [
-        "rest_framework.permissions.AllowAny",
+        "rest_framework.permissions.IsAuthenticatedOrReadOnly",
     ],
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
-# Pin versions as needed
-Django>=5.0
-djangorestframework>=3.15
-channels>=4.0
-django-cors-headers>=4.3.0
-uvicorn>=0.29  # for ASGI dev server
-psycopg2-binary>=2.9  # swap to pg8000 on AWS Lambda/App Runner if desired
-mangum>=0.17.0 
+# メジャー跳躍（破壊的更新）を防ぐため上限を付与。下限は現状維持。
+# 厳密な固定（pip-tools等）と pip-audit の CI 導入は別issue（#9）で対応予定。
+Django>=5.0,<6.0
+djangorestframework>=3.15,<4.0
+channels>=4.0,<5.0
+django-cors-headers>=4.3.0,<5.0
+uvicorn>=0.29,<1.0  # for ASGI dev server
+psycopg2-binary>=2.9,<3.0  # swap to pg8000 on AWS Lambda/App Runner if desired
+mangum>=0.17.0,<1.0


### PR DESCRIPTION
## 概要
バックエンドのセキュリティを強化。**UIの挙動は変えない**方針で実施・検証済み。

## 変更（UIへの影響なし）
- **認可**: DRF 既定権限を `IsAuthenticatedOrReadOnly` に。未認証の書込/削除を 403 で遮断。GET主体のUIは不変。学習進捗の記録（complete_lesson）は未認証でも呼べるよう維持しUXを保持。
- **本番設定**: `DEBUG=False` 時のみ有効なセキュリティ設定（HSTS / Secure Cookie / nosniff / proxy SSL header）。ローカル開発には影響なし。
- **起動ガード**: 本番で `DJANGO_SECRET_KEY` 未設定なら起動をブロック。
- **入力検証**: complete_lesson の不正入力を 500 ではなく 400 で返す。
- **依存**: メジャー跳躍防止の上限付与（`Django<6.0` 等）。

## 検証済み（ローカル実機）
- 解決版 Django **5.2.15 LTS** / `manage.py check` 通過。
- **6/6 テスト PASS**: 匿名GET=200・匿名POST/DELETE=403・complete_lesson匿名=200・不正入力=400・認証時は保存。
- 機密スキャン（pre-push-check）クリーン。

## ⚠️ デプロイ時の必須事項
反映時に Lambda 環境変数を更新（順序注意）:
- `DJANGO_DEBUG=False` / `DJANGO_SECRET_KEY=<新規生成>`（未設定だと起動ガードで失敗）
- `DJANGO_CORS_ALLOW_ALL=False` + `DJANGO_CORS_ALLOWED_ORIGINS` / `DJANGO_ALLOWED_HOSTS` を実ドメインに限定

> 🔒 具体的詳細は非公開アドバイザリ GHSA-g866-9q9f-537j。
Refs #2 #3 #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)